### PR TITLE
Fix Postgres numeric snapshot persistence

### DIFF
--- a/docs/current_status_and_usage.md
+++ b/docs/current_status_and_usage.md
@@ -23,11 +23,9 @@ What is not a product blocker anymore:
 
 What still remains outside product development:
 
-- GitHub/release operations
-- Demo deployment
-- `v2.0.0` tag and GitHub release publication
+- Optional demo deployment beyond local Docker
 
-In short: the coding phase for the baseline is complete, and the remaining work is release/ops-oriented.
+In short: the coding phase for the baseline is complete, `v2.0.0` has been published, and the remaining work is optional demo/ops polish.
 
 ## 2. Supported Runtime Modes
 
@@ -418,9 +416,9 @@ The baseline has already been verified through:
 
 - `ruff check .`
 - `ruff format --check .`
-- `pytest -q`
-- `pytest --cov=src --cov-report=term-missing -q`
-- Docker + PostgreSQL smoke validation
+- `pytest -q` (`33 passed, 2 skipped`)
+- `pytest --cov=src --cov-report=term-missing -q` (`33 passed, 2 skipped`, 75% coverage)
+- Docker + PostgreSQL smoke validation using `examples/sample_nist.csv`
 
 This means the current baseline is not just documented; it has already been exercised in both SQLite-oriented tests and PostgreSQL deployment-style flow.
 
@@ -430,9 +428,7 @@ No critical product development blockers are left in the baseline phase.
 
 What remains:
 
-- `v2.0.0` tag and GitHub release publication
-- repo settings and branch protection
 - issue/release hygiene
-- demo deployment
+- optional demo deployment beyond local Docker
 
-So the project is now in a public-shareable and release-prep state rather than an unfinished core-development state.
+So the project is now in a public-shareable baseline state rather than an unfinished core-development state.

--- a/docs/remaining_work_handoff.md
+++ b/docs/remaining_work_handoff.md
@@ -1,0 +1,256 @@
+# CurveIntel Remaining Work Handoff
+
+Last updated: 27 April 2026
+
+## Current Snapshot
+
+CurveIntel v2.0.0 baseline is functionally complete. The app is DB-backed, has FastAPI auth/RBAC, audit trail, admin backoffice, Docker/PostgreSQL runtime, CI, and public-readiness documentation.
+
+The latest local work fixed a real PostgreSQL smoke-test bug:
+
+- Branch: `codex/postgres-numeric-snapshot`
+- Commit: `6d36cbd` (`Fix Postgres numeric snapshot persistence`)
+- Remote branch: `origin/codex/postgres-numeric-snapshot`
+- Base branch: `main`
+- Current remote `main`: `48ab33f` (`Pin bcrypt below incompatible major`)
+- Current `v2.0.0` tag: still points to `48ab33f`
+
+The branch contains:
+
+- `src/curveintel/db/schemas.py`: indexed numeric snapshot fields are coerced to native Python `float` values before DB persistence.
+- `src/curveintel/db/serializers.py`: analysis payloads are passed through `make_json_ready`.
+- `tests/test_db.py`: regression coverage for NumPy scalar leakage.
+- `docs/current_status_and_usage.md`: verification status updated.
+- `planlar.md`: source-of-truth status updated.
+
+## Verified State
+
+These checks passed after the latest fix:
+
+```powershell
+ruff check .
+ruff format --check .
+pytest -q
+pytest --cov=src --cov-report=term-missing -q
+```
+
+Results:
+
+- `pytest -q`: `33 passed, 2 skipped`
+- coverage: `33 passed, 2 skipped`, `75%`
+
+Docker/PostgreSQL smoke also passed using `examples/sample_nist.csv`:
+
+- `/api/health`: `200`
+- `/`: `303` redirect to `/login`
+- `/login`: `200`
+- login as seeded admin: `200`
+- `/api/auth/me`: `200`
+- dashboard `/`: `200`
+- `POST /api/analyze`: `200`
+- `/api/results`: `200`
+- PDF download: `200`, about `88 KB`
+- `/api/audit-logs`: `200`
+
+The app was left runnable locally through Docker at:
+
+```text
+http://localhost:8000
+```
+
+## Important Local Notes
+
+- Local `.env` exists for Docker smoke and is gitignored.
+- For unit tests, temporarily move `.env` aside because seeded-admin settings can alter auth/bootstrap tests:
+
+```powershell
+Move-Item -LiteralPath .env -Destination .env.local-smoke -Force
+# run tests
+Move-Item -LiteralPath .env.local-smoke -Destination .env -Force
+```
+
+- Do not commit `.env`.
+- Do not print or persist any GitHub token. A PAT was previously pasted in chat; recommend the user revoke it after GitHub work is complete.
+- `gh` CLI was not installed in this environment.
+- Direct push to `main` is intentionally blocked by branch protection:
+
+```text
+GH006: Protected branch update failed
+Changes must be made through a pull request.
+5 of 5 required status checks are expected.
+```
+
+## What Is Left
+
+### 1. Open and Merge the Fix PR
+
+Open a PR from:
+
+```text
+codex/postgres-numeric-snapshot -> main
+```
+
+PR creation URL:
+
+```text
+https://github.com/Verm1lion/CurveIntel/pull/new/codex/postgres-numeric-snapshot
+```
+
+Suggested PR title:
+
+```text
+Fix Postgres numeric snapshot persistence
+```
+
+Suggested PR body:
+
+```markdown
+## Summary
+- Coerce indexed analysis snapshot numeric fields to native Python floats before persistence.
+- Normalize analysis payloads with `make_json_ready` so NumPy scalar values do not leak into PostgreSQL JSON/SQL parameters.
+- Update baseline status docs after local Docker/PostgreSQL smoke validation.
+
+## Root Cause
+PostgreSQL inserts failed during real Docker smoke because NumPy scalar values such as `np.float64(206.3)` could reach SQLAlchemy indexed columns. psycopg2 rendered that representation in SQL, producing a schema lookup error for `np`.
+
+## Validation
+- `ruff check .`
+- `ruff format --check .`
+- `pytest -q` (`33 passed, 2 skipped`)
+- `pytest --cov=src --cov-report=term-missing -q` (`33 passed, 2 skipped`, 75% coverage)
+- Docker Compose + PostgreSQL smoke: health, login, analyze CSV, results, PDF download, audit logs
+```
+
+After PR checks pass, merge it into `main`.
+
+### 2. Move the `v2.0.0` Tag to the Final Closing Commit
+
+After the PR is merged, move `v2.0.0` from `48ab33f` to the merge result or final main commit.
+
+Recommended sequence:
+
+```powershell
+git fetch origin --tags
+git switch main
+git pull --ff-only origin main
+git tag -f v2.0.0 HEAD
+git push origin v2.0.0 --force
+```
+
+Then update the GitHub release so it points to the final baseline commit. If GitHub does not automatically reflect the moved tag, edit the release target in the UI or recreate the release against the moved tag.
+
+### 3. Confirm GitHub Release and CI
+
+Confirm:
+
+- `main` includes `6d36cbd` or the merged equivalent.
+- `v2.0.0` points to the final commit, not `48ab33f`.
+- GitHub Actions required checks pass:
+  - `test (3.10)`
+  - `test (3.11)`
+  - `test (3.12)`
+  - `postgres-smoke`
+  - `docker`
+- Release page is still available:
+
+```text
+https://github.com/Verm1lion/CurveIntel/releases/tag/v2.0.0
+```
+
+### 4. Optional GitHub Repo Hygiene
+
+These are not product blockers, but they make the public repo look more complete:
+
+- Ensure repo description is set.
+- Ensure topics are set.
+- Create or clean issue labels.
+- Create 2-3 `good first issue` items.
+- Discussions can remain off unless the user wants community interaction.
+
+Suggested good-first-issue ideas:
+
+1. Add a short troubleshooting note for Docker Desktop startup and `COMPOSE_BAKE=false`.
+2. Add a small UI indicator for current database/runtime mode on the admin dashboard.
+3. Add one more documented sample CSV variant under `examples/`.
+
+### 5. Optional Demo Deployment
+
+The user clarified they are not going live right now. So no public domain is required.
+
+If demo deployment is still requested later, the realistic target remains Docker Compose + PostgreSQL on a VPS. Required environment items:
+
+- strong `JWT_SECRET_KEY`
+- seeded admin password or bootstrap-first-admin flow
+- `DATABASE_URL` for Postgres
+- CORS origins if accessed through a browser hostname
+- persistent volumes for Postgres and generated reports/uploads as needed
+
+Minimum smoke after deployment:
+
+- `/api/health`
+- `/login`
+- admin bootstrap/login
+- CSV analyze with `examples/sample_nist.csv`
+- PDF download
+- audit log view
+
+## Do Not Reopen Unless Needed
+
+The following are already done and should not be reworked without a specific user request:
+
+- DB-backed persistence architecture
+- auth/RBAC baseline
+- audit trail baseline
+- admin backoffice
+- Docker migration-first startup
+- CI baseline
+- public-readiness documentation
+- local Docker/PostgreSQL smoke validation
+
+## Quick Continuation Checklist
+
+1. Inspect `planlar.md`, `docs/current_status_and_usage.md`, and this file.
+2. Run `git status --short --branch`.
+3. Confirm branch `codex/postgres-numeric-snapshot` is pushed.
+4. Open PR to `main`.
+5. Wait for checks.
+6. Merge PR.
+7. Move `v2.0.0` tag to final commit.
+8. Update/confirm GitHub release.
+9. Optionally handle issue labels and good-first-issues.
+10. Tell the user to revoke the previously shared PAT.
+
+## Ready-To-Paste Prompt For Another Agent
+
+```text
+CurveIntel repo: C:\Users\MSI\Desktop\Test_Cihazlari_Proje\curveintel
+
+Please continue from the current repo state, not from assumptions. First read:
+- planlar.md
+- docs/current_status_and_usage.md
+- docs/remaining_work_handoff.md
+
+Then run:
+- git status --short --branch
+- git log --oneline -8 --decorate
+- git remote -v
+
+Current known state:
+- Latest fix branch is codex/postgres-numeric-snapshot.
+- Remote branch origin/codex/postgres-numeric-snapshot exists.
+- Latest commit is 6d36cbd, "Fix Postgres numeric snapshot persistence".
+- origin/main is at 48ab33f and v2.0.0 currently points there.
+- Direct push to main is blocked by branch protection and PR is required.
+- The fix branch already passed local lint/tests/coverage and Docker/PostgreSQL smoke.
+
+Your main job:
+1. Open a PR from codex/postgres-numeric-snapshot to main.
+2. Wait for required GitHub checks.
+3. Merge the PR if checks pass.
+4. Move v2.0.0 tag to the final merged main commit and update/confirm the GitHub release.
+5. Optionally finish GitHub repo hygiene: issue labels and 2-3 good-first-issues.
+
+Do not print, store, or commit any GitHub token. A PAT was previously shared in chat; after finishing, remind the user to revoke it.
+
+Do not redo core product work unless a check fails and the failure proves a real bug. The baseline is complete; remaining work is PR/release/ops hygiene.
+```

--- a/planlar.md
+++ b/planlar.md
@@ -16,6 +16,8 @@
 - [x] Ayrintili durum + kullanim + operator akisi dokumani eklendi
 - [x] `v2.0.0` baseline release notes taslagi eklendi
 - [x] Local `origin` remote URL tokenless HTTPS formatina cekildi
+- [x] GitHub `main`, `v2.0.0` tag/release ve branch protection yayina alindi
+- [x] Docker/PostgreSQL smoke sirasinda yakalanan NumPy scalar persist bug'i duzeltildi
 
 ---
 
@@ -211,27 +213,28 @@
 
 ## Sonraki Mantikli Adimlar
 
-1. Public-readiness commitini push et ve `v2.0.0` tag/release yayinini yap.
-2. GitHub repo ops islerini kapat:
-   topics/description/discussions, branch protection, issue labels, good-first-issues.
-3. Demo deployment ve release notlarini hazirla.
+1. PostgreSQL scalar persist fix'ini push et ve `v2.0.0` tag'ini son kapanis commit'ine tasidiktan sonra release'i guncelle.
+2. GitHub repo ops'ta kalan dusuk riskli hijyen islerini kapat:
+   issue labels ve 2-3 good-first-issue.
+3. Istenirse local Docker disinda demo deployment hazirla.
 
 ### Uygulama Notu
 - A, B ve C commitleri ayrildi; teknik baseline tamamlandi.
-- Release notes taslagi localde hazir; GitHub release yayini authenticated GitHub access gerektiriyor.
-- Sonraki teknik isler baseline stabilizasyonu degil, release/ops odakli.
+- GitHub release yayinda; branch protection ve CI required checks ayarlandi.
+- Local Docker/PostgreSQL demo uvicorn'a gore daha gercekci kabul edildi ve bu akista dogrulandi.
+- Sonraki teknik isler baseline stabilizasyonu degil, release/ops hijyeni odakli.
 
 ---
 
 ## Release Sonrasi / Ops
 
-- [ ] GitHub repo topics + description + discussions
-- [ ] branch protection
+- [x] GitHub repo topics + description
+- [x] branch protection
 - [ ] issue labels ve good-first-issues
-- [ ] demo deployment
+- [/] local Docker demo dogrulandi; harici demo deployment opsiyonel
 - [x] `v2.0.0` tag/release stratejisi yeni baseline commit'ine gore netlestirildi
 - [x] `v2.0.0` release notes taslagi hazirlandi
-- [ ] `v2.0.0` tag ve GitHub release yayini
+- [x] `v2.0.0` tag ve GitHub release yayini
 
 ---
 
@@ -242,4 +245,4 @@
 
 ---
 
-**Son guncelleme:** 27 Nisan 2026 - Public push readiness kapanis paketi hazirlandi; release notes taslagi eklendi, local remote tokenless hale getirildi; GitHub publish/ops ve demo deployment kuyrugu kaldi
+**Son guncelleme:** 27 Nisan 2026 - Local Docker/PostgreSQL demo smoke gecti; NumPy scalar persist bug'i duzeltildi; GitHub release ve branch protection yayinda, kalan isler issue hijyeni ve opsiyonel harici demo deployment.

--- a/src/curveintel/db/schemas.py
+++ b/src/curveintel/db/schemas.py
@@ -46,6 +46,17 @@ def _ensure_json_serializable(value: dict[str, Any], field_name: str) -> dict[st
     return value
 
 
+def _coerce_optional_float(value: Any) -> float | None:
+    """Coerce numeric payload values to native floats for DB drivers."""
+
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class UserCreate(BaseModel):
     """Validated input for creating a user record."""
 
@@ -184,51 +195,51 @@ class AnalysisSnapshotCreate(BaseModel):
         self.stress_type = self.stress_type or str(
             payload.get("stress_type") or context_metadata.get("stress_type") or "engineering"
         )
-        self.quality_score = (
+        self.quality_score = _coerce_optional_float(
             self.quality_score if self.quality_score is not None else quality.get("score")
         )
         self.quality_grade = self.quality_grade or quality.get("grade")
-        self.elastic_modulus_gpa = (
+        self.elastic_modulus_gpa = _coerce_optional_float(
             self.elastic_modulus_gpa
             if self.elastic_modulus_gpa is not None
             else props.get("elastic_modulus_gpa")
         )
-        self.yield_strength_mpa = (
+        self.yield_strength_mpa = _coerce_optional_float(
             self.yield_strength_mpa
             if self.yield_strength_mpa is not None
             else props.get("yield_strength_mpa")
         )
-        self.yield_lower_mpa = (
+        self.yield_lower_mpa = _coerce_optional_float(
             self.yield_lower_mpa
             if self.yield_lower_mpa is not None
             else props.get("yield_lower_mpa")
         )
-        self.ultimate_tensile_mpa = (
+        self.ultimate_tensile_mpa = _coerce_optional_float(
             self.ultimate_tensile_mpa
             if self.ultimate_tensile_mpa is not None
             else props.get("ultimate_tensile_mpa")
         )
-        self.elongation_at_break_pct = (
+        self.elongation_at_break_pct = _coerce_optional_float(
             self.elongation_at_break_pct
             if self.elongation_at_break_pct is not None
             else props.get("elongation_at_break_pct")
         )
-        self.uniform_elongation_pct = (
+        self.uniform_elongation_pct = _coerce_optional_float(
             self.uniform_elongation_pct
             if self.uniform_elongation_pct is not None
             else props.get("uniform_elongation_pct")
         )
-        self.strain_hardening_n = (
+        self.strain_hardening_n = _coerce_optional_float(
             self.strain_hardening_n
             if self.strain_hardening_n is not None
             else props.get("strain_hardening_n")
         )
-        self.strength_coefficient_k = (
+        self.strength_coefficient_k = _coerce_optional_float(
             self.strength_coefficient_k
             if self.strength_coefficient_k is not None
             else props.get("strength_coefficient_k")
         )
-        self.toughness_mj_m3 = (
+        self.toughness_mj_m3 = _coerce_optional_float(
             self.toughness_mj_m3
             if self.toughness_mj_m3 is not None
             else props.get("toughness_mj_m3")

--- a/src/curveintel/db/serializers.py
+++ b/src/curveintel/db/serializers.py
@@ -474,7 +474,7 @@ def build_analysis_payload(
     strain_rate_value = ctx.extra.get("strain_rate_median")
     strain_rate_compliant = ctx.extra.get("strain_rate_compliant")
 
-    return {
+    payload = {
         "id": result_id or str(uuid4()),
         "filename": filename,
         "timestamp": timestamp or utcnow_display(),
@@ -551,6 +551,7 @@ def build_analysis_payload(
             "critical": crit_count,
         },
     }
+    return make_json_ready(payload)
 
 
 def build_context_snapshot(ctx: AnalysisContext) -> dict[str, Any]:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -238,6 +238,22 @@ def test_legacy_ctx_to_dict_payload_is_backward_compatible(tmp_path: Path) -> No
     assert hydrated["analysis_payload"]["filename"] == "legacy.csv"
 
 
+def test_analysis_snapshot_coerces_numpy_scalars_for_postgres() -> None:
+    """Indexed DB fields should not leak NumPy scalar representations to SQL drivers."""
+
+    ctx = build_sample_context()
+    ctx.properties.elastic_modulus_gpa = np.float64(206.3)
+    ctx.properties.ultimate_tensile_mpa = np.float64(818.0)
+    ctx.properties.toughness_mj_m3 = np.float64(133.12)
+
+    snapshot = build_analysis_snapshot_from_context(ctx, filename="numpy-scalars.csv")
+
+    assert type(snapshot.elastic_modulus_gpa) is float
+    assert type(snapshot.ultimate_tensile_mpa) is float
+    assert type(snapshot.toughness_mj_m3) is float
+    assert type(snapshot.analysis_payload["properties"]["elastic_modulus_gpa"]) is float
+
+
 def test_persisted_context_snapshot_can_rehydrate_analysis_context(tmp_path: Path) -> None:
     """Persisted snapshots should reconstruct a usable AnalysisContext for reports."""
 


### PR DESCRIPTION
## Summary
- Coerce indexed analysis snapshot numeric fields to native Python floats before persistence.
- Normalize analysis payloads with `make_json_ready` so NumPy scalar values do not leak into PostgreSQL JSON/SQL parameters.
- Add remaining work handoff document for continuation context.
- Update baseline status docs after local Docker/PostgreSQL smoke validation.

## Root Cause
PostgreSQL inserts failed during real Docker smoke because NumPy scalar values such as `np.float64(206.3)` could reach SQLAlchemy indexed columns. psycopg2 rendered that representation in SQL, producing a schema lookup error for `np`.

## Validation
- `ruff check .`
- `ruff format --check .`
- `pytest -q` - 33 passed, 2 skipped
- `pytest --cov=src --cov-report=term-missing -q` - 33 passed, 2 skipped, 75% coverage
- Docker Compose + PostgreSQL smoke: health, login, analyze CSV, results, PDF download, audit logs