### PR TITLE
Added database badge to admin dashboard per request #9

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -580,6 +580,7 @@ async def dashboard(
         else []
     )
     admin_users = _get_user_payloads(db, include_inactive=True) if can_manage_results else []
+    db_mode = "SQLite" if os.getenv("DATABASE_URL", "sqlite://").startswith("sqlite") else "PostgreSQL"
     return render_template(
         request=request,
         name="dashboard.html",
@@ -607,6 +608,7 @@ async def dashboard(
                 "limit": audit_limit,
             },
             "workspace_copy": _workspace_copy(current_user.role),
+            "db_mode": db_mode,
         },
     )
 

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -256,6 +256,9 @@
             <span class="px-3 py-1 rounded-full border border-outline-variant/20 bg-surface-container text-on-surface-variant">
                 Management: <strong class="{% if can_manage_results %}text-tertiary-fixed{% else %}text-error{% endif %}">{% if can_manage_results %}admin only{% else %}read only{% endif %}</strong>
             </span>
+            <span class="px-3 py-1 rounded-full border border-outline-variant/20 bg-surface-container text-on-surface-variant">
+                Database: <strong class="text-tertiary-fixed">{{ db_mode }}</strong>
+            </span>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
Adds a runtime database mode badge to the admin dashboard header, showing whether the instance is running SQLite or PostgreSQL.

## Changes
- Added `db_mode` detection in the `dashboard` route in `web/app.py` based on the `DATABASE_URL` environment variable
- Passed `db_mode` to the dashboard template context
- Added a badge to the existing header badge row in `dashboard.html`

## Testing
Tested locally with SQLite — badge correctly displays "SQLite". PostgreSQL path follows the same logic, detecting the `postgresql` scheme in `DATABASE_URL`.

## Notes
Also noticed that validation errors containing a `ctx` field with a Python exception object cause a `TypeError` when serializing to JSON in `_api_error_response`. Happy to address that in a separate PR if useful.